### PR TITLE
Node version check in gulpfile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,13 @@
 'use strict';
 
+// Ensure we are running the correct version of Node
+var pkg = require('./package.json');
+if (process.version.substr(1) !== pkg.engines.node) {
+  console.error('\nYou are using the wrong Node version: ' + process.version);
+  console.error('\nTry this:\n  $ n ' + pkg.engines.node + '\n');
+  process.exit(1);
+}
+
 var fs = require('fs');
 var _ = require('lodash');
 


### PR DESCRIPTION
Currently if you run `gulp watch` and you're on Node 0.10.x, you get very cryptic errors. This prints a helpful message instead.
