### PR TITLE
Seat flow

### DIFF
--- a/client/js/sankey.main.js
+++ b/client/js/sankey.main.js
@@ -4,14 +4,19 @@ d3.sankey = require('./sankey/d3plugin.js');
 var debounce = require('lodash-node/modern/functions/debounce');
 var party = require('./data/party-data.js');
 var sankeyData = require('./sankey/sankey-data.js');
+var logo = require('./sankey/logo.js');
+
 var latestPredictions = 'http://www.ft.com/ig/data/electionforecast-co-uk/tsv/prediction-latest';
+
 var nodeWidth = 30;
+var updateString = '';
 
 d3.json('http://www.ft.com/ig/data/electionforecast-co-uk/updated.json',function(d){
   var updateTime = new Date(d.updated);
   //February 18, 2015 10:34 pm
   var timeFormat = d3.time.format("%B %e, %Y %I:%M %p");
-  d3.select('#updated').html( 'updated: ' + timeFormat(updateTime));
+  updateString = timeFormat(updateTime);
+  d3.select('#svg-source').text( 'Source: electionforecast.co.uk, ' + updateString );
 });
 
 d3.tsv(latestPredictions, function(d){
@@ -39,9 +44,9 @@ d3.tsv(latestPredictions, function(d){
 function drawSankey(data){
   d3.select('#sankey svg').remove();
   var parentSize = d3.select('#sankey').node().getBoundingClientRect();
-  var height = 500;
+  var height = 540;
   var width = parentSize.width;
-  var margin = {top:30,left:0,bottom:10,right:10};
+  var margin = {top:30,left:0,bottom:40,right:0};
   var chartHeight = height - (margin.top + margin.bottom);
   var chartWidth = width - (margin.left + margin.right);
   var nodePadding = 20;
@@ -167,7 +172,7 @@ function drawSankey(data){
       .attr('transform', function(d) { return 'translate(' + d.x + ',' + d.y + ')'; });
 
   node.append('rect')
-    .attr('height', function(d) { return d.dy; })
+    .attr('height', function(d) { return Math.max(1, d.dy); })
     .attr('width', sankey.nodeWidth())
     .attr('class',function(d){
       return 'node ' + toClass(d.name);
@@ -229,6 +234,16 @@ function drawSankey(data){
       selectLink( '.'+linkClass(d) );
       activateLabels('both', d.source.name, d.target.name);
     });
+
+  var logoGroup = svg.append('g');
+  logoGroup.call(logo);
+  logoGroup.attr('transform','translate(' + (width-32) + ',' + (height - 52) + ')');
+
+  var sourceGroup = svg.append('g');
+  sourceGroup.attr('transform','translate(0,' + (height-34) + ')');
+  sourceGroup.append('text').attr({
+    'id':'svg-source',
+  }).text('Source: electionforecast.co.uk, ' + updateString);
 }
 
 function pathHint(selectionString){

--- a/client/js/sankey/logo.js
+++ b/client/js/sankey/logo.js
@@ -1,0 +1,20 @@
+//the ft logo there's probably an easier way to do this...
+'use strict';
+
+function ftLogo(g, dim) {
+  if(!dim){
+    dim = 32;
+  }
+  var d = 'M21.777,53.336c0,6.381,1.707,7.1,8.996,7.37v2.335H1.801v-2.335c6.027-0.27,7.736-0.989,7.736-7.37v-41.67 c0-6.387-1.708-7.104-7.556-7.371V1.959h51.103l0.363,13.472h-2.519c-2.16-6.827-4.502-8.979-16.467-8.979h-9.27 c-2.785,0-3.415,0.624-3.415,3.142v19.314h4.565c9.54,0,11.61-1.712,12.779-8.089h2.338v21.559h-2.338 c-1.259-7.186-4.859-8.981-12.779-8.981h-4.565V53.336z M110.955,1.959H57.328l-1.244,13.477h3.073c1.964-6.601,4.853-8.984,11.308-8.984h7.558v46.884 c0,6.381-1.71,7.1-8.637,7.37v2.335H98.9v-2.335c-6.931-0.27-8.64-0.989-8.64-7.37V6.453h7.555c6.458,0,9.351,2.383,11.309,8.984 h3.075L110.955,1.959z';
+  var path = g.append('path').attr('d', d); //measure and rescale to the bounds
+  var rect = path.node().getBoundingClientRect();
+  //the logo is square so
+  var scale = Math.min (dim /rect.width, dim / rect.height);
+
+  path.attr({
+    'transform':'scale('+scale+')',
+    'fill':'rgba(0,0,0,0.1)'
+  });
+}
+
+module.exports = ftLogo;

--- a/templates/sankey-index.html
+++ b/templates/sankey-index.html
@@ -1,7 +1,9 @@
 
 {% extends 'article.html' %}
 
-{% block title %}Seat Flow: Parliamentary seat change forecast{% endblock %}
+
+{% block title %}Seat Flow: UK Parliament seat projection{% endblock %}
+
 
  {% block article_header %}
 {% endblock %}
@@ -11,8 +13,6 @@
   <h1 class="article-header__headline">Seat flow</h1>
   <div id="sankeyHolder" data-o-grid-colspan="12 M6 L6">
     <div id="sankey"></div>
-    <span id="updated"></span>
-    <div id="secondary-info" class="info-pane"></div>
   </div>
   <div id="sankey-description" class="" data-o-grid-colspan="12 M6 L6">
       <p id="inputs">
@@ -48,15 +48,14 @@
           </div>
         </li>
       </ul>
+      <div class="description"><b>What would happen if the UK General Election were held&nbsp;tomorrow?</b>
+        <p>This graphic shows a predicted redistribution of parliamentary seats. It is based on open data from <a href="http://electionforecast.co.uk/">electionforecast.co.uk</a> and is updated regularly.</p>
+      </div>
   </div>
-  <div id="selection-info" data-o-grid-colspan="12 M6 L6" class="info-pane"></div>
-</div>
-<div class="description">
-  <p>This graphic shows a predicted redistribution of parliamentary seats. It is based on open data from <a href="http://electionforecast.co.uk/">electionforecast.co.uk</a> and is updated regularly.</p>
 </div>
 <div class="notes">
-    <p>The model used by <a href="http://electionforecast.co.uk">electionforecast.co.uk</a> combines data provided by YouGov with publicly released polls, historical election results, and data from the UK Census.</p>
-    <p>Electionforecast.co.uk does not publish seat by seat predictions for Northern Ireland's 18 parliamentary seats these are included in &#8220;Others&#8221;</p>
+    <p>The model used by electionforecast.co.uk combines data provided by YouGov with publicly released polls, historical election results, and data from the UK Census.</p>
+    <p>electionforecast.co.uk does not publish seat by seat predictions for Northern Ireland's 18 parliamentary seats these are included in &#8220;Others&#8221;</p>
 </div>
 {% endblock %}
 
@@ -150,7 +149,7 @@ button{
   writing-mode: lr-tb;
 }
 
-#updated{
+#svg-source{
   color: rgb(119, 119, 119);
   display: inline;
   font-family: BentonSans, sans-serif;
@@ -270,6 +269,7 @@ path.link.hint, path.link:hover{
 #sankey-description{
   margin-top: 3px;
   padding-left: 1em;
+  font-family: BentonSans, sans-serif;
 }
 
 #inputs{
@@ -321,6 +321,7 @@ path.link.hint, path.link:hover{
 }
 
 .description{
+  padding-top: 1em;
   font-family: BentonSans, sans-serif;
   max-width:670px;
 }


### PR DESCRIPTION
adding FT logo and updated/ source stamp to the SVG itself for portability.

removing explicit seat listing now that the figures are on the links.

moving the description up to occupy the space where that list was