### PR TITLE
Update slope-data.js

### DIFF
--- a/client/js/group-forecast-slopes.main.js
+++ b/client/js/group-forecast-slopes.main.js
@@ -81,8 +81,8 @@ function main(){
 
   var slopeContainers = d3.selectAll('.constituency-group__slope-graphic').datum( function(){
       var datum = doc.data.constituencyLookup[this.dataset.constituency];
-    datum.axes = (Number(this.dataset.order) === 0);
-    return datum;
+      datum.axes = (Number(this.dataset.order) === 0);
+      return datum;
   });
 
   slopeContainers.append('svg').attr({
@@ -118,7 +118,7 @@ function main(){
           .attr({
             'class':'axis-label'
           })
-          .text(function(d){return d;});
+          .text(function(d){ return d; });
       }
       d3.select(this).selectAll('g.slope')
         .data( layout(d.parties) )

--- a/client/scss/graphics/_slope.scss
+++ b/client/scss/graphics/_slope.scss
@@ -62,6 +62,7 @@
     stroke: $green;
   }
 
+  .other-party, /* TODO: factor out all this party stuff so we're always referencing _party_elements.scss */
   .other {
     fill: $other;
     stroke: $other;

--- a/server/routers/data/slope-data.js
+++ b/server/routers/data/slope-data.js
@@ -8,7 +8,7 @@ function predictedWinner(record){
   var maxValue = 0;
   var winningParty = '';
   partylist.forEach(function(p){
-    var value = Number(record[parties.fullName(p)]);
+    var value = Number(record[parties.electionForecastName(p)]);
     maxValue = Math.max(value, maxValue);
     if(maxValue === value){
       winningParty = p;
@@ -50,8 +50,8 @@ function resultNormalise(r) {
 function predictionNormalise(r){
   var abbreviated = {};
   for(var item in r){
-    if(r.hasOwnProperty(item) && parties.fullNameToCode(item)){
-      abbreviated[ parties.fullNameToCode(item) ] = r[item];
+    if(r.hasOwnProperty(item) && parties.electionForecastToCode(item)){
+      abbreviated[ parties.electionForecastToCode(item) ] = r[item];
     }
   }
   return abbreviated;


### PR DESCRIPTION
Changing parties methods to work with the specific election forecast naming conventions i.e. UKIP, not Ukip (ft convention)
--
So the UKIP lines are not showing up on the projections page.
I believe this is because the name 'UKIP' was not being correctly converted to 'ukip',the normalised party code rather it was looking for 'Ukip'.

Anyway, I believe these changes should fix the situation but my home computer is rubbish so I can't test it (i.e. can't get the app running).

The Codeship light is green though so? 