### PR TITLE
Don't use protocol-relative URL for polyfill.io

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -29,7 +29,7 @@
 
         <script>{% spaceless %}
         if(cutsTheMustard){
-          addScript('//cdn.polyfill.io/v1/polyfill.min.js?features=default,Promise,fetch', false, false);
+          addScript('https://cdn.polyfill.io/v1/polyfill.min.js?features=default,Promise,fetch', false, false);
           addScript('{{ asset("js/vendor.js") }}', false, false);
           addScript('{{ asset("js/common.js") }}', false, false);
         }else{


### PR DESCRIPTION
The [polyfill.io](https://cdn.polyfill.io/v1/docs/) docs reccommend using https. Also Paul Irish said protocol-relative assets are [now an anti-pattern](http://www.paulirish.com/2010/the-protocol-relative-url/) for other reasons.

In any case I think it's safer to guarantee against dodgy reverse caching proxies failing to respect the Vary header, which is crucial for polyfill.io. With https we guarantee each client gets its own copy.