### PR TITLE
Corrected link coalition explainer

### DIFF
--- a/templates/coalition-calculator.html
+++ b/templates/coalition-calculator.html
@@ -7,7 +7,7 @@
 {% endblock %}
 {% block article_body %}
   <div class="scenarios" data-o-grid-colspan="12 M10 center">
-    <p></p><a href="http://elections.ft.com/uk/2015/projections">Polls suggest</a> that the <a href="http://www.ft.com/indepth/uk-general-election">UK general election</a> on May 7 will result in a hung parliament. A coalition, or a minority government backed by a &ldquo;confidence and supply&rdquo; deal with other parties, is likely to come to power. This graphic shows the scenarios possible based on the <a href="#" class="preset-adjustment selected"
+    <p></p><a href="http://elections.ft.com/uk/2015/projections">Polls suggest</a> that the <a href="http://www.ft.com/indepth/uk-general-election">UK general election</a> on May 7 will result in a hung parliament. A coalition, or a minority government backed by a &ldquo;confidence and supply&rdquo; deal with other parties, is <a href="http://www.ft.com/cms/s/0/89471a34-e8d0-11e4-87fe-00144feab7de.html">likely to come to power</a>. This graphic shows the scenarios possible based on the <a href="#" class="preset-adjustment selected"
     {% for party in efdata.data %}
     data-{{ party.Party }}="{{party.Seats}}"
     {% endfor %}>current&nbsp;projection</a> from <a href="http://www.electionforecast.co.uk">ElectionForecast.co.uk</a>. Compare this to the <a href="#" class="preset-adjustment"

--- a/templates/projections-index.html
+++ b/templates/projections-index.html
@@ -17,7 +17,7 @@
 
 {% block article_body %}
 
-<div class="o-grid-row">i
+<div class="o-grid-row">
 
   {% if overview && overview.length %}
   <div class="figure" data-o-grid-colspan="12">

--- a/templates/projections-index.html
+++ b/templates/projections-index.html
@@ -17,7 +17,7 @@
 
 {% block article_body %}
 
-<div class="o-grid-row">
+<div class="o-grid-row">i
 
   {% if overview && overview.length %}
   <div class="figure" data-o-grid-colspan="12">
@@ -44,7 +44,7 @@
       </div>
       <div data-o-grid-colspan="12 M5 L4">
         <p>According to this projection a hung parliament is likely. There are few viable coalitions, but multiple ad hoc alliances are possible.</p>
-        <p><a href="http://www.ft.com/cms/s/0/49bd976a-d79d-11e4-849b-00144feab7de.html">If no coalition can form a majority</a>, a &ldquo;confidence and supply&rdquo; deal with smaller parties could allow a minority Conservative or Labour government to pass its Queen&rsquo;s Speech and its Budget. All other issues would then be decided vote by vote.</p>
+        <p><a href="http://www.ft.com/cms/s/0/89471a34-e8d0-11e4-87fe-00144feab7de.html">If no coalition can form a majority</a>, a &ldquo;confidence and supply&rdquo; deal with smaller parties could allow a minority Conservative or Labour government to pass its Queen&rsquo;s Speech and its Budget. All other issues would then be decided vote by vote.</p>
         <div class="figure__footer">
           <p>Although 326 seats is a majority in the House of Commons, Sinn F&eacute;in MPs do not take their seats, so the number of seats needed to win a vote will be lower, most likely 323.</p>
         </div>


### PR DESCRIPTION
We have a better explainer for post-election scenarios, so I have changed links to that.