### PR TITLE
Add exit poll option to coalition calculator

### DIFF
--- a/templates/coalition-calculator.html
+++ b/templates/coalition-calculator.html
@@ -1,4 +1,4 @@
-{% extends 'article.html' %}
+	{% extends 'article.html' %}
 
 {% set stylesheet = 'pages/coalition-calculator.css' %}
 
@@ -11,7 +11,16 @@
     <a href="http://elections.ft.com/uk/2015/projections">Polls suggest</a> that the <a href="http://www.ft.com/indepth/uk-general-election">UK general election</a> on May 7 will result in a hung parliament. A coalition, or a minority government backed by a &ldquo;confidence and supply&rdquo; deal with other parties, is <a href="http://www.ft.com/cms/s/0/89471a34-e8d0-11e4-87fe-00144feab7de.html">likely to come to power</a>. This graphic shows the scenarios possible based on the <a href="#" class="preset-adjustment selected"
     {% for party in efdata.data %}
     data-{{ party.Party }}="{{party.Seats}}"
-    {% endfor %}>current&nbsp;projection</a> from <a href="http://www.electionforecast.co.uk">ElectionForecast.co.uk</a>. Compare this to the <a href="#" class="preset-adjustment"
+    {% endfor %}>final&nbsp;pre-election&nbsp;projection</a> from <a href="http://www.electionforecast.co.uk">ElectionForecast.co.uk</a>. Compare this to the <a href="#" class="preset-adjustment"
+    data-c="316"
+    data-lab="239"
+    data-ld="10"
+    data-snp="58"
+    data-pc="4"
+    data-ukip="2"
+    data-green="2"
+    data-other="19">
+    exit&nbsp;poll</a>, the <a href="#" class="preset-adjustment"
     data-c="302"
     data-lab="256"
     data-ld="56"


### PR DESCRIPTION
Also fixes wording to explain that the default is the final pre-election forecast.